### PR TITLE
Fix ReferenceError: data is not defined in pusherService

### DIFF
--- a/controllers/deploymentController.js
+++ b/controllers/deploymentController.js
@@ -21,7 +21,7 @@ exports.triggerDeploymentStatus = async (req, res) => {
 
     // 3. When everything is finished, send the success event
     const data = req.body;
-    await pusherService.sendSuccess(data);
+    await pusherService.sendStatusUpdate(data);
 
     // --- End of your deployment logic ---
 

--- a/services/pusherService.js
+++ b/services/pusherService.js
@@ -12,12 +12,12 @@ const pusher = new Pusher({
  * Call this function multiple times during your deployment 
  * to send real-time log messages to the frontend.
  */
-exports.sendLogUpdate = async (logMessage) => { await pusher.trigger('my-channel', 'log-update', data); };
+exports.sendLogUpdate = async (logMessage) => { await pusher.trigger('my-channel', 'log-update', { message: logMessage }); };
 
 /**
  * Call this function if the deployment fails at any point.
  */
-exports.sendError = async (errorMessage) => { await pusher.trigger('my-channel', 'deployment-error', data); };
+exports.sendError = async (errorMessage) => { await pusher.trigger('my-channel', 'deployment-error', { message: errorMessage }); };
 
 /**
  * Call this function only once at the very end when the 


### PR DESCRIPTION
The `sendLogUpdate` and `sendError` functions in `services/pusherService.js` were attempting to use an undefined `data` variable, causing a `ReferenceError` during deployment.

This commit fixes the issue by replacing the undefined variable with an object containing the message payload, e.g., `{ message: logMessage }`.

Additionally, it corrects a typo in `controllers/deploymentController.js` by renaming a call to the non-existent `sendSuccess` function to the correct `sendStatusUpdate` function.