### PR TITLE
feat: Refactor server to be a Pusher webhook forwarder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,91 @@
-# Render Server Streaming with Pusher
+# Pusher Webhook Forwarding Server
 
-This is a Node.js application that demonstrates how to use server-sent events (SSE) with Pusher to stream deployment logs to the client.
+This is a simple Node.js application that acts as a secure webhook receiver to forward events to Pusher.
+
+## Use Case
+
+This server is designed to be a bridge between a service that can send webhooks (like GitHub Actions, a CI/CD pipeline, or a custom backend service) and your frontend application that listens for real-time events with Pusher.
+
+Instead of exposing your Pusher credentials directly in your CI/CD environment, you can have your pipeline send a webhook to this server. This server, which securely stores your Pusher credentials, will then relay the event to the appropriate Pusher channel.
 
 ## Getting Started
 
-1. **Clone the repository:**
+1.  **Clone the repository:**
+    ```bash
+    git clone https://github.com/your-username/render-server-streaming.git
+    ```
 
-   ```bash
-   git clone https://github.com/your-username/render-server-streaming.git
-   ```
+2.  **Install dependencies:**
+    ```bash
+    npm install
+    ```
 
-2. **Install dependencies:**
+3.  **Create a `.env` file** and add your Pusher credentials. You can copy the `.env.example` file if one exists.
+    ```
+    PUSHER_APP_ID="your_app_id"
+    PUSHER_APP_KEY="your_key"
+    PUSHER_SECRET="your_secret"
+    PUSHER_CLUSTER="your_cluster"
+    ```
 
-   ```bash
-   npm install
-   ```
+4.  **Start the server:**
+    ```bash
+    npm start
+    ```
+    The server will be running at `http://localhost:3000`.
 
-3. **Create a `app.env` file** and add your Pusher credentials:
+## API Endpoint
 
-   ```
-   PUSHER_APP_ID="your_app_id"
-   PUSHER_KEY="your_key"
-   PUSHER_SECRET="your_secret"
-   PUSHER_CLUSTER="your_cluster"
-   ```
+### `POST /trigger-event`
 
-4. **Start the server:**
+Receives a webhook payload and forwards it as an event to one or more Pusher channels.
 
-   ```bash
-   npm start
-   ```
+**Request Body:**
 
-The server will be running at `http://localhost:3000`.
+The request body must be a JSON object with the following fields:
 
-## API Endpoints
+-   `channels` (Array of strings): A list of Pusher channels to send the event to.
+-   `name` (string): The name of the event.
+-   `data` (object): The JSON payload to send with the event.
 
-- `GET /deployments/:id/stream`: Stream deployment logs for a given deployment ID.
+**Example Payload:**
+
+```json
+{
+  "channels": ["my-channel"],
+  "name": "log-update",
+  "data": {
+    "message": "Deployment step 1/3: Cloning repository..."
+  }
+}
+```
+
+**Example `curl` Request:**
+
+```bash
+curl -X POST \
+  http://localhost:3000/trigger-event \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "channels": ["my-channel"],
+        "name": "log-update",
+        "data": { "message": "Hello from curl!" }
+      }'
+```
+
+**Success Response (200 OK):**
+
+```json
+{
+  "message": "Event forwarded successfully to Pusher."
+}
+```
+
+**Error Response (400 Bad Request):**
+
+If the request body is missing required fields.
+```json
+{
+  "error": "Request body must include \"channels\", \"name\", and \"data\" fields."
+}
+```

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,6 +2,6 @@ const express = require('express');
 const router = express.Router();
 const deploymentController = require('../controllers/deploymentController');
 
-router.post('/trigger-event', deploymentController.triggerDeploymentStatus);
+router.post('/trigger-event', deploymentController.forwardPusherEvent);
 
 module.exports = router;

--- a/services/pusherService.js
+++ b/services/pusherService.js
@@ -9,18 +9,11 @@ const pusher = new Pusher({
 });
 
 /**
- * Call this function multiple times during your deployment 
- * to send real-time log messages to the frontend.
+ * Triggers an event on a specified Pusher channel.
+ * @param {string} channel - The name of the channel.
+ * @param {string} eventName - The name of the event.
+ * @param {object} data - The payload to send with the event.
  */
-exports.sendLogUpdate = async (logMessage) => { await pusher.trigger('my-channel', 'log-update', { message: logMessage }); };
-
-/**
- * Call this function if the deployment fails at any point.
- */
-exports.sendError = async (errorMessage) => { await pusher.trigger('my-channel', 'deployment-error', { message: errorMessage }); };
-
-/**
- * Call this function only once at the very end when the 
- * deployment has completed successfully.
- */
-exports.sendStatusUpdate = async (data) => { await pusher.trigger('my-channel', 'deployment-success', data); };
+exports.triggerEvent = async (channel, eventName, data) => {
+  await pusher.trigger(channel, eventName, data);
+};


### PR DESCRIPTION
This commit refactors the entire application based on user feedback. The server no longer simulates a deployment process. Instead, it now functions as a simple and secure webhook forwarder for Pusher.

Key changes:
- The `/trigger-event` endpoint now accepts a POST request with `channels`, `name`, and `data` in the body.
- A generic `triggerEvent` function was created in the `pusherService` to handle any event type.
- The controller logic was replaced to validate the incoming webhook and forward it to Pusher.
- The `README.md` has been completely rewritten to document the new functionality, API, and use case.